### PR TITLE
feat: Projects一覧にもっと見る/追加枠を追加

### DIFF
--- a/src/components/home/home-cms-content.tsx
+++ b/src/components/home/home-cms-content.tsx
@@ -10,7 +10,11 @@ import { WorkSection } from "@/components/home/work";
 import { fallbackProjects, fallbackServices } from "@/lib/contentful/fallbacks";
 import { mapProjectsToMoreProjectItems, mapProjectsToWorkItems } from "@/lib/contentful/mappers";
 import type { ProjectsResult, ServicesResult, SnsLinksResult } from "@/lib/contentful/types";
-import { staticFooterContent, staticSectionTitles } from "@/lib/site-content";
+import {
+	staticFooterContent,
+	staticProjectsSectionContent,
+	staticSectionTitles,
+} from "@/lib/site-content";
 
 async function fetchContentfulResource<T>(url: string) {
 	const response = await fetch(url);
@@ -37,7 +41,13 @@ export function HomeCmsContent() {
 
 	return (
 		<>
-			<WorkSection title={staticSectionTitles.work} items={workItems} />
+			<WorkSection
+				initialVisibleCount={staticProjectsSectionContent.initialVisibleCount}
+				items={workItems}
+				showLessLabel={staticProjectsSectionContent.showLessLabel}
+				showMoreLabel={staticProjectsSectionContent.showMoreLabel}
+				title={staticSectionTitles.work}
+			/>
 			<MoreProjectsSection
 				isPlaceholder={isPlaceholderData}
 				items={moreProjectItems}

--- a/src/components/home/work.tsx
+++ b/src/components/home/work.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
 import { ProjectWorkCard, type WorkItem } from "@/components/home/project-work-card";
 import { AnimatedSectionTitle } from "@/components/motion/animated-section-title";
 import { GsapStaggerGroup } from "@/components/motion/gsap-stagger-group";
@@ -8,21 +12,51 @@ export type { WorkItem };
 type WorkSectionProps = {
 	title?: string;
 	items?: WorkItem[];
+	initialVisibleCount?: number;
+	showMoreLabel?: string;
+	showLessLabel?: string;
 };
 
-export function WorkSection({ title = "Work", items = [] }: WorkSectionProps) {
+export function WorkSection({
+	title = "Work",
+	items = [],
+	initialVisibleCount = 3,
+	showMoreLabel = "もっと見る",
+	showLessLabel = "表示を閉じる",
+}: WorkSectionProps) {
+	const [expanded, setExpanded] = useState(false);
+	const visibleCount = Math.max(1, initialVisibleCount);
+	const hasHiddenItems = items.length > visibleCount;
+	const visibleItems = useMemo(
+		() => (expanded || !hasHiddenItems ? items : items.slice(0, visibleCount)),
+		[expanded, hasHiddenItems, items, visibleCount],
+	);
+	const hiddenCount = Math.max(0, items.length - visibleCount);
+
 	return (
 		<section id="work" className="w-full">
 			<HomeMainInner className="md:gap-section-lg flex flex-col gap-6">
 				<AnimatedSectionTitle title={title} titleClassName="md:text-section-lg md:font-black" />
 
 				<GsapStaggerGroup className="gap-block-lg flex flex-col">
-					{items.map((item, index) => (
+					{visibleItems.map((item, index) => (
 						<div key={`${item.title}-${index}`} data-gsap-item>
 							<ProjectWorkCard {...item} />
 						</div>
 					))}
 				</GsapStaggerGroup>
+
+				{hasHiddenItems ? (
+					<div className="flex">
+						<button
+							type="button"
+							className="text-caption text-primary md:text-body decoration-primary/50 inline-flex items-center gap-2 underline underline-offset-4 transition-opacity hover:opacity-80"
+							onClick={() => setExpanded((previous) => !previous)}
+						>
+							{expanded ? showLessLabel : `${showMoreLabel}（追加枠 ${hiddenCount}件）`}
+						</button>
+					</div>
+				) : null}
 			</HomeMainInner>
 		</section>
 	);

--- a/src/lib/site-content.ts
+++ b/src/lib/site-content.ts
@@ -130,6 +130,12 @@ export const staticSectionTitles = {
 	services: "Services",
 };
 
+export const staticProjectsSectionContent = {
+	initialVisibleCount: 3,
+	showMoreLabel: "もっと見る",
+	showLessLabel: "表示を閉じる",
+};
+
 export const staticFooterContent = {
 	backToTopLabel: "Back to top",
 	copyright: "© 2026, All rights reserved",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- Work（Projects）セクションの初期表示件数を超えるプロジェクトを折りたたみ、`もっと見る` で展開できるようにしました
- 折りたたみ時は `もっと見る（追加枠 N件）` の形式で、追加枠の件数を明示します
- 表示件数とトグル文言を `site-content` のProjects向けデータ定義から渡せるようにしました

## 変更ファイル
- `src/components/home/work.tsx`
- `src/components/home/home-cms-content.tsx`
- `src/lib/site-content.ts`

## 確認観点
- Work セクションに4件以上ある場合、初期表示が3件になること
- `もっと見る` クリックで全件表示、`表示を閉じる` クリックで初期件数に戻ること

Closes #13
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd51514f-800e-4f20-8a88-0aa3c883bef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd51514f-800e-4f20-8a88-0aa3c883bef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

