### PR TITLE
Implement Services section content and Contentful schema polish

### DIFF
--- a/contentful/migrations/002-create-services.ts
+++ b/contentful/migrations/002-create-services.ts
@@ -8,6 +8,9 @@ const migration: MigrationFunction = (migration) => {
 		.displayField("title");
 
 	services.createField("title").name("Title").type("Symbol").required(true);
+	services.changeFieldControl("title", "builtin", "singleLine", {
+		helpText: "Service category title shown in the Services section.",
+	});
 
 	services
 		.createField("point")
@@ -17,6 +20,9 @@ const migration: MigrationFunction = (migration) => {
 			type: "Symbol",
 		})
 		.required(true);
+	services.changeFieldControl("point", "builtin", "tagEditor", {
+		helpText: "Bullet points displayed under each service category.",
+	});
 };
 
 export default migration;

--- a/src/components/home/services.tsx
+++ b/src/components/home/services.tsx
@@ -19,13 +19,13 @@ function ServiceGroup({ title, points }: ServiceItem) {
 			<h3 className="text-section text-foreground md:w-full md:text-right md:text-[72px] md:leading-none md:font-bold">
 				{title}
 			</h3>
-			<div className="text-caption text-foreground md:text-body flex flex-col gap-16 leading-normal md:flex-row md:flex-wrap md:gap-4">
+			<ul className="text-caption text-foreground md:text-body flex flex-col gap-16 leading-normal md:flex-row md:flex-wrap md:gap-4">
 				{points.map((point, index) => (
-					<p key={`${title}-${index}`} className="md:w-[240px]">
+					<li key={`${title}-${index}`} className="list-none md:w-[240px]">
 						{point}
-					</p>
+					</li>
 				))}
-			</div>
+			</ul>
 		</section>
 	);
 }
@@ -36,13 +36,21 @@ export function ServicesSection({ title = "Services", items = [] }: ServicesSect
 			<HomeMainInner className="gap-block md:gap-section-lg flex flex-col">
 				<AnimatedSectionTitle title={title} titleClassName="md:text-section-lg md:font-black" />
 
-				<div className="gap-block-lg md:gap-section-lg flex flex-col">
-					{items.map((item, index) => (
-						<SectionReveal key={item.id ?? `${item.title}-${index}`} delay={index * 0.06} y={24}>
-							<ServiceGroup {...item} />
-						</SectionReveal>
-					))}
-				</div>
+				{items.length > 0 ? (
+					<div className="gap-block-lg md:gap-section-lg flex flex-col">
+						{items.map((item, index) => (
+							<SectionReveal key={item.id ?? `${item.title}-${index}`} delay={index * 0.06} y={24}>
+								<ServiceGroup {...item} />
+							</SectionReveal>
+						))}
+					</div>
+				) : (
+					<SectionReveal delay={0.06} y={24}>
+						<p className="text-caption text-foreground/80 md:text-body max-w-[680px] leading-relaxed">
+							サービス内容は現在更新中です。Contentful の Services エントリー公開後に、こちらへ最新の提供内容を表示します。
+						</p>
+					</SectionReveal>
+				)}
 			</HomeMainInner>
 		</section>
 	);

--- a/src/lib/contentful/fallbacks.ts
+++ b/src/lib/contentful/fallbacks.ts
@@ -13,9 +13,34 @@ export const fallbackProjects: ProjectsResult = {
 };
 
 export const fallbackServices: ServicesResult = {
-	items: [],
+	items: [
+		{
+			id: "fallback-service-website",
+			title: "Website Development",
+			points: [
+				"Next.js と TypeScript をベースに、保守性の高いコーポレート/ポートフォリオサイトを設計・実装します。",
+				"SEO、パフォーマンス、アクセシビリティを考慮した情報設計と UI 実装を行います。",
+			],
+		},
+		{
+			id: "fallback-service-cms",
+			title: "Headless CMS Integration",
+			points: [
+				"Contentful などの CMS とフロントエンドを接続し、運用しやすいコンテンツ管理フローを構築します。",
+				"API 設計、型安全なデータ取得、フォールバック戦略まで含めて実装します。",
+			],
+		},
+		{
+			id: "fallback-service-operations",
+			title: "Operation & Improvement",
+			points: [
+				"公開後の分析・改善サイクルを前提に、機能追加しやすい構成でプロジェクトを整備します。",
+				"表示品質や動作安定性を担保するため、テストや監視を取り入れた運用基盤を提案します。",
+			],
+		},
+	],
 	source: "fallback",
-	reason: "Contentful credentials are not configured yet.",
+	reason: "Contentful credentials are not configured yet. Showing local starter services.",
 };
 
 export const fallbackSnsLinks: SnsLinksResult = {

--- a/src/lib/contentful/mappers/service.test.ts
+++ b/src/lib/contentful/mappers/service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { mapServiceEntry, mapServices } from "@/lib/contentful/mappers/service";
+import type { ContentfulEntry } from "@/lib/contentful/mappers/shared";
+
+function serviceEntry(overrides: Partial<ContentfulEntry["fields"]> = {}): ContentfulEntry {
+	return {
+		sys: { id: "service-1" },
+		fields: {
+			title: " Website Development ",
+			point: ["Build modern websites", "Improve performance"],
+			...overrides,
+		},
+	};
+}
+
+describe("service mappers", () => {
+	it("maps a Contentful services entry into display-safe service data", () => {
+		expect(mapServiceEntry(serviceEntry())).toEqual({
+			id: "service-1",
+			title: "Website Development",
+			points: ["Build modern websites", "Improve performance"],
+		});
+	});
+
+	it("returns null when the entry is missing required fields", () => {
+		expect(mapServiceEntry(serviceEntry({ title: "", point: [] }))).toBeNull();
+	});
+
+	it("filters invalid entries while mapping services collection", () => {
+		const valid = serviceEntry();
+		const invalid = serviceEntry({
+			title: "",
+			point: [],
+		});
+
+		expect(mapServices([valid, invalid]).items).toEqual([
+			{
+				id: "service-1",
+				title: "Website Development",
+				points: ["Build modern websites", "Improve performance"],
+			},
+		]);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Issue #10（services）対応として、Services セクションを実装・補強しました。

## 変更内容
- `src/components/home/services.tsx`
  - Services の各ポイントを `ul/li` で構造化
  - Services データが 0 件の場合の空状態メッセージを追加
- `src/lib/contentful/fallbacks.ts`
  - Contentful 未設定時でも Services が表示されるよう、提供サービスのフォールバックデータを追加
- `contentful/migrations/002-create-services.ts`
  - Services content type の編集UIヘルプテキストを追加し、入力意図を明確化
- `src/lib/contentful/mappers/service.test.ts`
  - Services マッパーの単体テストを追加（正常系・不正データ・コレクション変換）

## テスト
- `npm run test -- src/lib/contentful/mappers/service.test.ts`
  - 実行結果: `vitest: not found`（この実行環境で依存コマンド未導入のため未実行）

## スコープ
- Services 関連ファイルのみに変更を限定
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7321244-8f92-4345-86f0-1f643b33a6cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7321244-8f92-4345-86f0-1f643b33a6cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

