### PR TITLE
ProjectsセクションをCMS取得に統一しContentfulスキーマを強化

### DIFF
--- a/contentful/migrations/008-require-project-display-sections.ts
+++ b/contentful/migrations/008-require-project-display-sections.ts
@@ -1,0 +1,41 @@
+import type { MigrationFunction } from "contentful-migration";
+
+const migration: MigrationFunction = (migration) => {
+	migration.transformEntries({
+		contentType: "projects",
+		from: ["displaySections"],
+		to: ["displaySections"],
+		transformEntryForLocale: (fromFields, locale) => {
+			const currentValue = fromFields.displaySections?.[locale];
+
+			if (Array.isArray(currentValue) && currentValue.length > 0) {
+				return {
+					displaySections: currentValue,
+				};
+			}
+
+			return {
+				displaySections: ["work"],
+			};
+		},
+	});
+
+	const projects = migration.editContentType("projects");
+
+	projects
+		.editField("displaySections")
+		.name("Display sections")
+		.type("Array")
+		.items({
+			type: "Symbol",
+			validations: [
+				{
+					in: ["work", "moreProjects"],
+				},
+			],
+		})
+		.validations([{ size: { min: 1 } }])
+		.required(true);
+};
+
+export default migration;

--- a/contentful/scripts/migrate.ts
+++ b/contentful/scripts/migrate.ts
@@ -9,6 +9,7 @@ import createContact from "../migrations/004-create-contact";
 import addProjectDisplaySections from "../migrations/005-add-project-display-sections";
 import createContactInquiries from "../migrations/006-create-contact-inquiries";
 import createContactFormSettings from "../migrations/007-create-contact-form-settings";
+import requireProjectDisplaySections from "../migrations/008-require-project-display-sections";
 
 loadEnvConfig(process.cwd());
 
@@ -25,6 +26,7 @@ const migrations: NamedMigration[] = [
 	{ id: "005-add-project-display-sections", migrationFunction: addProjectDisplaySections },
 	{ id: "006-create-contact-inquiries", migrationFunction: createContactInquiries },
 	{ id: "007-create-contact-form-settings", migrationFunction: createContactFormSettings },
+	{ id: "008-require-project-display-sections", migrationFunction: requireProjectDisplaySections },
 ];
 
 function getFlagValue(flagName: string) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/home/home-cms-content";
 import { HomeIntro } from "@/components/home/home-intro";
 import { LayoutGuides } from "@/components/ui/layout-guides";
-import { getSnsLinks } from "@/lib/contentful/queries";
+import { getProjects, getSnsLinks } from "@/lib/contentful/queries";
 import {
 	staticAboutContent,
 	staticChatContent,
@@ -19,7 +19,7 @@ import {
 export const revalidate = 300;
 
 export default async function HomePage() {
-	const snsLinks = await getSnsLinks();
+	const [projects, snsLinks] = await Promise.all([getProjects(), getSnsLinks()]);
 
 	return (
 		<div id="top" className="relative flex flex-col gap-[28px] md:gap-[56px]">
@@ -30,7 +30,7 @@ export default async function HomePage() {
 				sinceLabel={staticHeaderContent.sinceLabel}
 			/>
 			<main className="relative z-20 flex w-full flex-col gap-[96px] md:gap-[240px]">
-				<HomeCmsContent />
+				<HomeCmsContent initialProjects={projects} />
 				<AboutSection
 					blocks={staticAboutContent.blocks}
 					imageAlt={staticAboutContent.portraitImageAlt}

--- a/src/components/home/home-cms-content.tsx
+++ b/src/components/home/home-cms-content.tsx
@@ -22,11 +22,16 @@ async function fetchContentfulResource<T>(url: string) {
 	return (await response.json()) as T;
 }
 
-export function HomeCmsContent() {
+type HomeCmsContentProps = {
+	initialProjects?: ProjectsResult;
+};
+
+export function HomeCmsContent({ initialProjects }: HomeCmsContentProps) {
 	const { data: projects = fallbackProjects, isPlaceholderData } = useQuery({
 		queryKey: ["contentful", "projects"],
 		queryFn: () => fetchContentfulResource<ProjectsResult>("/api/contentful/projects"),
-		placeholderData: fallbackProjects,
+		initialData: initialProjects,
+		placeholderData: initialProjects ?? fallbackProjects,
 	});
 
 	const workItems = mapProjectsToWorkItems(projects.items);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- HomeページでProjectsをサーバー側で先読みし、`HomeCmsContent`へ初期データとして注入
- React QueryのProjectsクエリに`initialData`を設定し、初期表示時からCMSデータを利用
- Contentful migration `008-require-project-display-sections` を追加し、`projects.displaySections` を必須化（既存未設定エントリは `work` へ補完）

## 変更ファイル
- `src/app/page.tsx`
- `src/components/home/home-cms-content.tsx`
- `contentful/migrations/008-require-project-display-sections.ts`
- `contentful/scripts/migrate.ts`

## 補足
- 変更範囲はProjectsのデータ取得とContentfulスキーマ関連に限定しています。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-631f51ef-0023-41cf-91f3-69d8958f195f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-631f51ef-0023-41cf-91f3-69d8958f195f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

