### PR TITLE
feat: implement centralized siteSettings with Contentful schema

### DIFF
--- a/contentful/migrations/008-create-site-settings.ts
+++ b/contentful/migrations/008-create-site-settings.ts
@@ -1,0 +1,75 @@
+import type { MigrationFunction } from "contentful-migration";
+
+const migration: MigrationFunction = (migration) => {
+	const siteSettings = migration
+		.createContentType("siteSettings")
+		.name("Site Settings")
+		.description("Singleton settings for site metadata and footer links.")
+		.displayField("title");
+
+	siteSettings.createField("title").name("Title").type("Symbol").required(true);
+
+	siteSettings
+		.createField("description")
+		.name("Description")
+		.type("Text")
+		.required(true);
+
+	siteSettings
+		.createField("siteName")
+		.name("Site Name")
+		.type("Symbol")
+		.required(true);
+
+	siteSettings.createField("locale").name("Locale").type("Symbol").required(true);
+
+	siteSettings
+		.createField("keywords")
+		.name("Keywords")
+		.type("Array")
+		.items({
+			type: "Symbol",
+		})
+		.required(true);
+
+	siteSettings
+		.createField("twitterHandle")
+		.name("Twitter Handle")
+		.type("Symbol")
+		.required(false);
+
+	siteSettings
+		.createField("footerEmail")
+		.name("Footer Email")
+		.type("Symbol")
+		.required(true);
+
+	siteSettings
+		.createField("footerCopyright")
+		.name("Footer Copyright")
+		.type("Symbol")
+		.required(true);
+
+	siteSettings
+		.createField("footerBackToTopLabel")
+		.name("Footer Back To Top Label")
+		.type("Symbol")
+		.required(true);
+
+	siteSettings
+		.createField("socialLinks")
+		.name("Social Links")
+		.type("Array")
+		.items({
+			type: "Link",
+			linkType: "Entry",
+			validations: [
+				{
+					linkContentType: ["snsLinks"],
+				},
+			],
+		})
+		.required(false);
+};
+
+export default migration;

--- a/src/app/api/contentful/site-settings/route.ts
+++ b/src/app/api/contentful/site-settings/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { getSiteSettings } from "@/lib/contentful/queries";
+
+export async function GET() {
+	const siteSettings = await getSiteSettings();
+
+	return NextResponse.json(siteSettings);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from "react";
 import { MotionProvider } from "@/components/providers/motion-provider";
 import { QueryProvider } from "@/components/providers/query-provider";
 import { SmoothScrollProvider } from "@/components/providers/smooth-scroll-provider";
+import { getSiteSettings } from "@/lib/contentful/queries";
 import { env } from "@/lib/env";
 import { staticSiteMetadata } from "@/lib/site-content";
 import "./globals.css";
@@ -34,35 +35,37 @@ const devtoolsMessage = `\n
 `;
 
 export async function generateMetadata(): Promise<Metadata> {
+	const siteSettings = await getSiteSettings();
 	const metadataBase = new URL(env.NEXT_PUBLIC_SITE_URL);
 	const ogImage = "/ogp.png";
 
 	return {
-		title: staticSiteMetadata.title,
-		description: staticSiteMetadata.description,
-		keywords: staticSiteMetadata.keywords,
+		title: siteSettings.title,
+		description: siteSettings.description,
+		keywords: siteSettings.keywords,
 		metadataBase,
 		alternates: {
 			canonical: "/",
 		},
 		openGraph: {
-			title: staticSiteMetadata.title,
-			description: staticSiteMetadata.description,
+			title: siteSettings.title,
+			description: siteSettings.description,
 			url: "/",
-			siteName: staticSiteMetadata.siteName,
-			locale: staticSiteMetadata.locale,
+			siteName: siteSettings.siteName,
+			locale: siteSettings.locale,
 			type: "website",
 			images: [
 				{
 					url: ogImage,
-					alt: staticSiteMetadata.title,
+					alt: siteSettings.title,
 				},
 			],
 		},
 		twitter: {
 			card: "summary_large_image",
-			title: staticSiteMetadata.title,
-			description: staticSiteMetadata.description,
+			title: siteSettings.title,
+			description: siteSettings.description,
+			creator: siteSettings.twitterHandle,
 			images: [ogImage],
 		},
 		authors: [{ name: staticSiteMetadata.person.name }],
@@ -82,14 +85,15 @@ export async function generateMetadata(): Promise<Metadata> {
 	};
 }
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default async function RootLayout({ children }: RootLayoutProps) {
+	const siteSettings = await getSiteSettings();
 	const personStructuredData = {
 		"@context": "https://schema.org",
 		"@type": "Person",
 		name: staticSiteMetadata.person.name,
 		alternateName: staticSiteMetadata.person.alternateNames,
 		url: env.NEXT_PUBLIC_SITE_URL,
-		description: staticSiteMetadata.description,
+		description: siteSettings.description,
 		jobTitle: staticSiteMetadata.person.jobTitle,
 		address: {
 			"@type": "PostalAddress",
@@ -99,6 +103,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
 		},
 		areaServed: staticSiteMetadata.person.areaServed,
 		knowsAbout: staticSiteMetadata.person.knowsAbout,
+		sameAs: siteSettings.socialLinks.map((item) => item.url),
 	};
 
 	return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/home/home-cms-content";
 import { HomeIntro } from "@/components/home/home-intro";
 import { LayoutGuides } from "@/components/ui/layout-guides";
-import { getSnsLinks } from "@/lib/contentful/queries";
+import { getSiteSettings } from "@/lib/contentful/queries";
 import {
 	staticAboutContent,
 	staticChatContent,
@@ -19,7 +19,7 @@ import {
 export const revalidate = 300;
 
 export default async function HomePage() {
-	const snsLinks = await getSnsLinks();
+	const siteSettings = await getSiteSettings();
 
 	return (
 		<div id="top" className="relative flex flex-col gap-[28px] md:gap-[56px]">
@@ -47,7 +47,7 @@ export default async function HomePage() {
 				<HomeServicesContent />
 				<ContactSection />
 			</main>
-			<HomeFooterContent initialSnsLinks={snsLinks} />
+			<HomeFooterContent initialSiteSettings={siteSettings} />
 		</div>
 	);
 }

--- a/src/components/home/home-cms-content.tsx
+++ b/src/components/home/home-cms-content.tsx
@@ -9,7 +9,7 @@ import { ServicesSection } from "@/components/home/services";
 import { WorkSection } from "@/components/home/work";
 import { fallbackProjects, fallbackServices } from "@/lib/contentful/fallbacks";
 import { mapProjectsToMoreProjectItems, mapProjectsToWorkItems } from "@/lib/contentful/mappers";
-import type { ProjectsResult, ServicesResult, SnsLinksResult } from "@/lib/contentful/types";
+import type { ProjectsResult, ServicesResult, SiteSettings } from "@/lib/contentful/types";
 import { staticFooterContent, staticSectionTitles } from "@/lib/site-content";
 
 async function fetchContentfulResource<T>(url: string) {
@@ -58,22 +58,22 @@ export function HomeServicesContent() {
 }
 
 type HomeFooterContentProps = {
-	initialSnsLinks: SnsLinksResult;
+	initialSiteSettings: SiteSettings;
 };
 
-export function HomeFooterContent({ initialSnsLinks }: HomeFooterContentProps) {
-	const { data: snsLinks = initialSnsLinks } = useQuery({
-		queryKey: ["contentful", "sns-links"],
-		queryFn: () => fetchContentfulResource<SnsLinksResult>("/api/contentful/sns-links"),
-		initialData: initialSnsLinks,
+export function HomeFooterContent({ initialSiteSettings }: HomeFooterContentProps) {
+	const { data: siteSettings = initialSiteSettings } = useQuery({
+		queryKey: ["contentful", "site-settings"],
+		queryFn: () => fetchContentfulResource<SiteSettings>("/api/contentful/site-settings"),
+		initialData: initialSiteSettings,
 	});
 
 	return (
 		<Footer
-			backToTopLabel={staticFooterContent.backToTopLabel}
-			copyright={staticFooterContent.copyright}
-			email={staticFooterContent.email}
-			socialLinks={snsLinks.items.map((item) => ({ label: item.title, href: item.url }))}
+			backToTopLabel={siteSettings.footerBackToTopLabel ?? staticFooterContent.backToTopLabel}
+			copyright={siteSettings.footerCopyright ?? staticFooterContent.copyright}
+			email={siteSettings.footerEmail ?? staticFooterContent.email}
+			socialLinks={siteSettings.socialLinks.map((item) => ({ label: item.title, href: item.url }))}
 		/>
 	);
 }

--- a/src/lib/contentful/fallbacks.ts
+++ b/src/lib/contentful/fallbacks.ts
@@ -2,9 +2,11 @@ import type {
 	ContactFormSettings,
 	ProjectsResult,
 	ServicesResult,
+	SiteSettings,
 	SnsLinksResult,
 } from "@/lib/contentful/types";
 import { contactTopics } from "@/lib/contact/topics";
+import { staticFooterContent, staticSiteMetadata } from "@/lib/site-content";
 
 export const fallbackProjects: ProjectsResult = {
 	items: [],
@@ -28,6 +30,21 @@ export const fallbackContactFormSettings: ContactFormSettings = {
 	id: "fallback-contact-form-settings",
 	title: "Contact Form Settings",
 	topicOptions: [...contactTopics],
+	source: "fallback",
+	reason: "Contentful credentials are not configured yet.",
+};
+
+export const fallbackSiteSettings: SiteSettings = {
+	id: "fallback-site-settings",
+	title: staticSiteMetadata.title,
+	description: staticSiteMetadata.description,
+	siteName: staticSiteMetadata.siteName,
+	locale: staticSiteMetadata.locale,
+	keywords: [...staticSiteMetadata.keywords],
+	footerEmail: staticFooterContent.email,
+	footerCopyright: staticFooterContent.copyright,
+	footerBackToTopLabel: staticFooterContent.backToTopLabel,
+	socialLinks: [],
 	source: "fallback",
 	reason: "Contentful credentials are not configured yet.",
 };

--- a/src/lib/contentful/mappers/index.ts
+++ b/src/lib/contentful/mappers/index.ts
@@ -1,5 +1,6 @@
 export * from "./contact-form-settings";
 export * from "./project";
 export * from "./service";
+export * from "./site-settings";
 export * from "./shared";
 export * from "./sns-link";

--- a/src/lib/contentful/mappers/site-settings.ts
+++ b/src/lib/contentful/mappers/site-settings.ts
@@ -1,0 +1,45 @@
+import { fallbackSiteSettings } from "@/lib/contentful/fallbacks";
+import { mapSnsLinkEntry } from "@/lib/contentful/mappers/sns-link";
+import {
+	asEntryArray,
+	asString,
+	asStringArray,
+	type ContentfulEntry,
+} from "@/lib/contentful/mappers/shared";
+import {
+	siteSettingsSchema,
+	type SiteSettings,
+} from "@/lib/contentful/types/site-settings";
+import type { SnsLink } from "@/lib/contentful/types/sns-link";
+
+export function mapSiteSettingsEntry(entry: ContentfulEntry | undefined): SiteSettings {
+	if (!entry?.fields) {
+		return fallbackSiteSettings;
+	}
+
+	const fields = entry.fields;
+	const socialLinks = asEntryArray(fields.socialLinks)
+		.map(mapSnsLinkEntry)
+		.filter((item): item is SnsLink => item !== null);
+
+	const parsed = siteSettingsSchema.safeParse({
+		id: entry.sys.id,
+		title: asString(fields.title) ?? fallbackSiteSettings.title,
+		description: asString(fields.description) ?? fallbackSiteSettings.description,
+		siteName: asString(fields.siteName) ?? fallbackSiteSettings.siteName,
+		locale: asString(fields.locale) ?? fallbackSiteSettings.locale,
+		keywords: asStringArray(fields.keywords).length
+			? asStringArray(fields.keywords)
+			: fallbackSiteSettings.keywords,
+		twitterHandle: asString(fields.twitterHandle),
+		footerEmail: asString(fields.footerEmail) ?? fallbackSiteSettings.footerEmail,
+		footerCopyright:
+			asString(fields.footerCopyright) ?? fallbackSiteSettings.footerCopyright,
+		footerBackToTopLabel:
+			asString(fields.footerBackToTopLabel) ?? fallbackSiteSettings.footerBackToTopLabel,
+		socialLinks,
+		source: "contentful",
+	});
+
+	return parsed.success ? parsed.data : fallbackSiteSettings;
+}

--- a/src/lib/contentful/queries/get-site-settings.ts
+++ b/src/lib/contentful/queries/get-site-settings.ts
@@ -1,0 +1,33 @@
+import { cache } from "react";
+
+import { fallbackSiteSettings } from "@/lib/contentful/fallbacks";
+import { mapSiteSettingsEntry } from "@/lib/contentful/mappers";
+import { getSingleEntryByContentType } from "@/lib/contentful/queries/shared";
+import type { SiteSettings } from "@/lib/contentful/types";
+import { integrationStatus } from "@/lib/env";
+
+export const getSiteSettings = cache(async (): Promise<SiteSettings> => {
+	if (!integrationStatus.hasContentful) {
+		return fallbackSiteSettings;
+	}
+
+	try {
+		const entry = await getSingleEntryByContentType("siteSettings", 2);
+
+		if (!entry) {
+			return {
+				...fallbackSiteSettings,
+				reason: "No published site settings entry was found in Contentful.",
+			};
+		}
+
+		return mapSiteSettingsEntry(entry);
+	} catch (error) {
+		console.error("Failed to fetch site settings from Contentful", error);
+
+		return {
+			...fallbackSiteSettings,
+			reason: "Contentful request failed, so local site settings are shown instead.",
+		};
+	}
+});

--- a/src/lib/contentful/queries/index.ts
+++ b/src/lib/contentful/queries/index.ts
@@ -3,6 +3,7 @@ import { getProjects } from "@/lib/contentful/queries/get-projects";
 export * from "./get-contact-form-settings";
 export * from "./get-projects";
 export * from "./get-services";
+export * from "./get-site-settings";
 export * from "./get-sns-links";
 
 export type ContentPreview = {

--- a/src/lib/contentful/types/index.ts
+++ b/src/lib/contentful/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./contact-form-settings";
 export * from "./project";
 export * from "./service";
+export * from "./site-settings";
 export * from "./sns-link";

--- a/src/lib/contentful/types/site-settings.ts
+++ b/src/lib/contentful/types/site-settings.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+import { snsLinkSchema } from "@/lib/contentful/types/sns-link";
+
+export const siteSettingsSchema = z.object({
+	id: z.string().min(1).optional(),
+	title: z.string().min(1),
+	description: z.string().min(1),
+	siteName: z.string().min(1),
+	locale: z.string().min(1),
+	keywords: z.array(z.string().min(1)).min(1),
+	twitterHandle: z.string().min(1).optional(),
+	footerEmail: z.string().min(1),
+	footerCopyright: z.string().min(1),
+	footerBackToTopLabel: z.string().min(1),
+	socialLinks: z.array(snsLinkSchema),
+	source: z.enum(["contentful", "fallback"]),
+	reason: z.string().optional(),
+});
+
+export type SiteSettings = z.infer<typeof siteSettingsSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- Contentful に singleton の `siteSettings` モデルを追加しました（migration: `008-create-site-settings.ts`）
- `siteSettings` 用の型・mapper・query・API route を追加し、サイト設定を一元取得できるようにしました
- `layout` のメタ情報と `footer` の SNS / メール / 文言を `siteSettings` 参照に切り替えました

## 変更点
- 追加: `contentful/migrations/008-create-site-settings.ts`
- 追加: `src/lib/contentful/types/site-settings.ts`
- 追加: `src/lib/contentful/mappers/site-settings.ts`
- 追加: `src/lib/contentful/queries/get-site-settings.ts`
- 追加: `src/app/api/contentful/site-settings/route.ts`
- 更新: `src/lib/contentful/{types,mappers,queries}/index.ts` に export を追加
- 更新: `src/lib/contentful/fallbacks.ts` に `fallbackSiteSettings` を追加
- 更新: `src/app/layout.tsx` でメタ情報を `getSiteSettings()` から生成
- 更新: `src/app/page.tsx` / `src/components/home/home-cms-content.tsx` で footer データ取得を `siteSettings` に統合

## 動作確認
- `npm run typecheck`
- `npm run lint`

## 補足
- 既存の `snsLinks` コンテンツタイプは互換のため保持し、`siteSettings.socialLinks` から参照する構成にしています。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f8d20a-0b62-4cde-bd6d-9145d1211dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f8d20a-0b62-4cde-bd6d-9145d1211dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

